### PR TITLE
Add another rating category in the CSS

### DIFF
--- a/script.js
+++ b/script.js
@@ -199,7 +199,14 @@ var WatchedIndicator = React.createClass({
 var Rating = React.createClass({
   render: function() {
     var rating = parseFloat(this.props.val);
-    var ratingClass = rating >= 8 ? 'high' : 'med';
+    if(rating < 8) {
+      var ratingClass = "low"
+    } else if (rating < 9) {
+      var ratingClass = "med"
+    } else {
+      var ratingClass = "high"
+    }
+
     return (
       <span className={'rating rating-' + ratingClass}>{this.props.val}</span>
     )

--- a/style.css
+++ b/style.css
@@ -125,6 +125,10 @@ h3 {
   background: #B46A0B;
 }
 
+.episode .rating-low {
+  background: #9E6C2C;
+}
+
 .watched {
   font-size: 26px;
   padding: 16px 8px 20px 16px;


### PR DESCRIPTION
This will allow styling of the rating color button on three levels
instead of two. It does make sense to potentially add either more levels
or have a gradient, based on the rating value.

The color selected for 'low' is completely arbitrary and in general, the
allocation of the colors to the rating category is arbitrary. Might make
sense to change them so that they match the theme of the site.
